### PR TITLE
php 7.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "yiisoft/yii2": "^2.0.0",
+        "yiisoft/yii2": "~2.0.13",
         "league/tactician": "^0.6.0"
     },
     "autoload": {

--- a/src/base/BaseCommand.php
+++ b/src/base/BaseCommand.php
@@ -2,12 +2,12 @@
 
 namespace trntv\tactician\base;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * @author Eugene Terentev <eugene@terentev.net>
  */
-class BaseCommand extends Object
+class BaseCommand extends BaseObject
 {
 
 }

--- a/src/base/BaseHandler.php
+++ b/src/base/BaseHandler.php
@@ -2,12 +2,12 @@
 
 namespace trntv\tactician\base;
 
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * @author Eugene Terentev <eugene@terentev.net>
  */
-abstract class BaseHandler extends Object
+abstract class BaseHandler extends BaseObject
 {
     /**
      * @param BaseCommand $command


### PR DESCRIPTION
* Use `yii\base\BaseObject` instead of `yii\base\Object`
* Yii2 minimum version set to 2.0.13, due to absence of `yii\base\BaseObject` in previous versions.